### PR TITLE
comment out Transmission schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     'nomad-analysis', # develop branch
     'lakeshore-nomad-plugin @ git+https://github.com/IKZ-Berlin/lakeshore-nomad-plugin.git@69a6deb3f0e99d7b0dc66714105dd62a56f157e9',
     'laytec_epitt_plugin @ git+https://github.com/IKZ-Berlin/laytec_epitt_nomad_plugin.git@f4953ac4ecb55b7003dee323d7d7f473e49ab4e3',
-    'transmission @ git+https://github.com/FAIRmat-NFDI/AreaA-data_modeling_and_schemas.git@de012ac8820dbb514f5dd73aafdf46bf2a879481#subdirectory=transmission/transmission_plugin/uv_vis_nir_transmission_plugin',
+    # 'transmission @ git+https://github.com/FAIRmat-NFDI/AreaA-data_modeling_and_schemas.git@de012ac8820dbb514f5dd73aafdf46bf2a879481#subdirectory=transmission/transmission_plugin/uv_vis_nir_transmission_plugin',
 ]
 
 [project.optional-dependencies]

--- a/src/nomad_ikz_plugin/characterization/schema.py
+++ b/src/nomad_ikz_plugin/characterization/schema.py
@@ -17,11 +17,11 @@ from nomad.datamodel.metainfo.plot import (
     PlotlyFigure,
 )
 from nomad.metainfo import Datetime, MEnum, Quantity, SchemaPackage, Section, SubSection
-from transmission.schema import (
-    ELNUVVisNirTransmission,
-    UVVisNirTransmissionResult,
-    UVVisNirTransmissionSettings,
-)
+# from transmission.schema import (
+#     ELNUVVisNirTransmission,
+#     UVVisNirTransmissionResult,
+#     UVVisNirTransmissionSettings,
+# )
 
 from nomad_ikz_plugin.general.schema import (
     IKZCategory,
@@ -157,157 +157,157 @@ class LightMicroscope(Measurement, SubstratePreparationStep, EntryData):
     )
 
 
-class IKZUVVisNirTransmissionSettings(UVVisNirTransmissionSettings):
-    """
-    Section for the settings of the instrument used for transmission measurement.
-    """
+# class IKZUVVisNirTransmissionSettings(UVVisNirTransmissionSettings):
+#     """
+#     Section for the settings of the instrument used for transmission measurement.
+#     """
 
-    ordinate_type = Quantity(
-        type=MEnum(['%T', 'A']),
-        description=(
-            'Specifies whether the ordinate (y-axis) of the measurement data is '
-            'percent transmittance (%T) or absorbance (A).'
-        ),
-        a_eln={'component': 'EnumEditQuantity'},
-    )
-
-
-class IKZUVVisNirTransmissionResult(UVVisNirTransmissionResult):
-    """
-    Section for the results of the UV-Vis NIR Transmission measurement.
-    """
-
-    m_def = Section(
-        a_eln=ELNAnnotation(
-            properties=SectionProperties(
-                order=[
-                    'transmittance',
-                    'absorbance',
-                    'wavelength',
-                    'extinction_coefficient',
-                ],
-                visible=Filter(
-                    exclude=[
-                        'array_index',
-                    ],
-                ),
-            )
-        )
-    )
-    extinction_coefficient = Quantity(
-        type=np.float64,
-        description=(
-            'Extinction coefficient calculated from transmittance and sample thickness '
-            'values: -log(T)/L. The coefficient includes the effects of '
-            'absorption, reflection, and scattering.'
-        ),
-        shape=['*'],
-        unit='1/m',
-        a_plot={'x': 'array_index', 'y': 'extinction_coefficient'},
-    )
-
-    def generate_plots(self) -> list[PlotlyFigure]:
-        """
-        Extends UVVisNirTransmissionResult.generate_plots() method to include the plotly
-        figures for the `IKZUVVisNirTransmissionResult` section.
-
-        Returns:
-            list[PlotlyFigure]: The plotly figures.
-        """
-        figures = super().generate_plots()
-        if self.wavelength is None:
-            return figures
-
-        # generate plot for extinction coefficient
-        if self.extinction_coefficient is None:
-            return figures
-
-        x = self.wavelength.to('nm').magnitude
-        x_label = 'Wavelength'
-        xaxis_title = x_label + ' (nm)'
-
-        y = self.extinction_coefficient.to('1/cm').magnitude
-        y_label = 'Extinction coefficient'
-        yaxis_title = y_label + ' (1/cm)'
-
-        line_linear = px.line(x=x, y=y)
-
-        line_linear.update_layout(
-            title=f'{y_label} over {x_label}',
-            xaxis_title=xaxis_title,
-            yaxis_title=yaxis_title,
-            xaxis=dict(
-                fixedrange=False,
-            ),
-            yaxis=dict(
-                fixedrange=False,
-            ),
-            template='plotly_white',
-        )
-
-        figures.append(
-            PlotlyFigure(
-                label=f'{y_label} linear plot',
-                figure=line_linear.to_plotly_json(),
-            ),
-        )
-
-        return figures
-
-    def calculate_extinction_coefficient(self, archive, logger):
-        """
-        Calculate the extinction coefficient from the transmittance and sample
-        thickness. The formula used is: -log( T[%] / 100 ) / L.
-
-        Args:
-            archive (EntryArchive): The archive containing the section.
-            logger (BoundLogger): A structlog logger.
-        """
-        self.extinction_coefficient = None
-        if not archive.data.samples:
-            logger.warning(
-                'Cannot calculate extinction coefficient as sample not found.'
-            )
-            return
-        if not archive.data.samples[0].thickness:
-            logger.warning(
-                'Cannot calculate extinction coefficient as sample thickness not found '
-                'or the value is 0.'
-            )
-            return
-
-        path_length = archive.data.samples[0].thickness
-        if self.transmittance is not None:
-            extinction_coeff = -np.log(self.transmittance) / path_length
-            # TODO: The if-block is a temperary fix to avoid processing of nans in
-            # the archive. The issue will be fixed in the future.
-            if np.any(np.isnan(extinction_coeff)):
-                logger.warning(
-                    'Failed to save extinction coefficient. '
-                    'Encountered NaN values in the calculation.'
-                )
-                return
-            self.extinction_coefficient = extinction_coeff
-
-    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
-        """
-        The normalizer for the `IKZUVVisNirTransmissionResult` class.
-
-        Args:
-            archive (EntryArchive): The archive containing the section that is being
-            normalized.
-            logger (BoundLogger): A structlog logger.
-        """
-        super().normalize(archive, logger)
-        self.calculate_extinction_coefficient(archive, logger)
+#     ordinate_type = Quantity(
+#         type=MEnum(['%T', 'A']),
+#         description=(
+#             'Specifies whether the ordinate (y-axis) of the measurement data is '
+#             'percent transmittance (%T) or absorbance (A).'
+#         ),
+#         a_eln={'component': 'EnumEditQuantity'},
+#     )
 
 
-class ELNIKZUVVisNirTransmission(ELNUVVisNirTransmission):
-    m_def = Section()
+# class IKZUVVisNirTransmissionResult(UVVisNirTransmissionResult):
+#     """
+#     Section for the results of the UV-Vis NIR Transmission measurement.
+#     """
 
-    results = Measurement.results.m_copy()
-    results.section_def = IKZUVVisNirTransmissionResult
+#     m_def = Section(
+#         a_eln=ELNAnnotation(
+#             properties=SectionProperties(
+#                 order=[
+#                     'transmittance',
+#                     'absorbance',
+#                     'wavelength',
+#                     'extinction_coefficient',
+#                 ],
+#                 visible=Filter(
+#                     exclude=[
+#                         'array_index',
+#                     ],
+#                 ),
+#             )
+#         )
+#     )
+#     extinction_coefficient = Quantity(
+#         type=np.float64,
+#         description=(
+#             'Extinction coefficient calculated from transmittance and sample thickness '
+#             'values: -log(T)/L. The coefficient includes the effects of '
+#             'absorption, reflection, and scattering.'
+#         ),
+#         shape=['*'],
+#         unit='1/m',
+#         a_plot={'x': 'array_index', 'y': 'extinction_coefficient'},
+#     )
 
-    transmission_settings = SubSection(
-        section_def=IKZUVVisNirTransmissionSettings,
-    )
+#     def generate_plots(self) -> list[PlotlyFigure]:
+#         """
+#         Extends UVVisNirTransmissionResult.generate_plots() method to include the plotly
+#         figures for the `IKZUVVisNirTransmissionResult` section.
+
+#         Returns:
+#             list[PlotlyFigure]: The plotly figures.
+#         """
+#         figures = super().generate_plots()
+#         if self.wavelength is None:
+#             return figures
+
+#         # generate plot for extinction coefficient
+#         if self.extinction_coefficient is None:
+#             return figures
+
+#         x = self.wavelength.to('nm').magnitude
+#         x_label = 'Wavelength'
+#         xaxis_title = x_label + ' (nm)'
+
+#         y = self.extinction_coefficient.to('1/cm').magnitude
+#         y_label = 'Extinction coefficient'
+#         yaxis_title = y_label + ' (1/cm)'
+
+#         line_linear = px.line(x=x, y=y)
+
+#         line_linear.update_layout(
+#             title=f'{y_label} over {x_label}',
+#             xaxis_title=xaxis_title,
+#             yaxis_title=yaxis_title,
+#             xaxis=dict(
+#                 fixedrange=False,
+#             ),
+#             yaxis=dict(
+#                 fixedrange=False,
+#             ),
+#             template='plotly_white',
+#         )
+
+#         figures.append(
+#             PlotlyFigure(
+#                 label=f'{y_label} linear plot',
+#                 figure=line_linear.to_plotly_json(),
+#             ),
+#         )
+
+#         return figures
+
+#     def calculate_extinction_coefficient(self, archive, logger):
+#         """
+#         Calculate the extinction coefficient from the transmittance and sample
+#         thickness. The formula used is: -log( T[%] / 100 ) / L.
+
+#         Args:
+#             archive (EntryArchive): The archive containing the section.
+#             logger (BoundLogger): A structlog logger.
+#         """
+#         self.extinction_coefficient = None
+#         if not archive.data.samples:
+#             logger.warning(
+#                 'Cannot calculate extinction coefficient as sample not found.'
+#             )
+#             return
+#         if not archive.data.samples[0].thickness:
+#             logger.warning(
+#                 'Cannot calculate extinction coefficient as sample thickness not found '
+#                 'or the value is 0.'
+#             )
+#             return
+
+#         path_length = archive.data.samples[0].thickness
+#         if self.transmittance is not None:
+#             extinction_coeff = -np.log(self.transmittance) / path_length
+#             # TODO: The if-block is a temperary fix to avoid processing of nans in
+#             # the archive. The issue will be fixed in the future.
+#             if np.any(np.isnan(extinction_coeff)):
+#                 logger.warning(
+#                     'Failed to save extinction coefficient. '
+#                     'Encountered NaN values in the calculation.'
+#                 )
+#                 return
+#             self.extinction_coefficient = extinction_coeff
+
+#     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
+#         """
+#         The normalizer for the `IKZUVVisNirTransmissionResult` class.
+
+#         Args:
+#             archive (EntryArchive): The archive containing the section that is being
+#             normalized.
+#             logger (BoundLogger): A structlog logger.
+#         """
+#         super().normalize(archive, logger)
+#         self.calculate_extinction_coefficient(archive, logger)
+
+
+# class ELNIKZUVVisNirTransmission(ELNUVVisNirTransmission):
+#     m_def = Section()
+
+#     results = Measurement.results.m_copy()
+#     results.section_def = IKZUVVisNirTransmissionResult
+
+#     transmission_settings = SubSection(
+#         section_def=IKZUVVisNirTransmissionSettings,
+#     )


### PR DESCRIPTION
this removes the transmission schema from the nomad-ikz-plugin temporarily until @ka-sarthak implemts an update strategy that preserves old NOMAD entries.