### PR TITLE
fix: ensure name for PLD proces is set only if not already defined by user

### DIFF
--- a/src/nomad_ikz_plugin/pld/schema.py
+++ b/src/nomad_ikz_plugin/pld/schema.py
@@ -983,7 +983,8 @@ class IKZPulsedLaserDeposition(PulsedLaserDeposition, PlotSection, EntryData):
                 match['datetime'],
                 r'%d%m%Y_%H%M',
             ).astimezone()
-            self.name = match['name']
+            if not self.name:
+                self.name = match['name']
             if self.process_identifiers is None:
                 self.process_identifiers = ReadableIdentifiers(
                     institute='IKZ',


### PR DESCRIPTION
Now one can set the name for the PLD process and it will be picked up again in the lab id for the process. Before it was always picking from the log files which could cause duplicate process ids when two process were don eon the same day.