### PR TITLE
Fix test pipeline

### DIFF
--- a/nomad.yaml
+++ b/nomad.yaml
@@ -1,0 +1,4 @@
+plugins:
+  entry_points:
+    exclude:
+      - "nomad_measurements.transmission:parser"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -20,7 +19,7 @@ name = "nomad-ikz-plugin"
 dynamic = ["version"]
 description = "A plugin for NOMAD containing IKZ use cases."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Hampus Näsström", email = 'hampus.naesstroem@physik.hu-berlin.de' },
     { name = "Andrea Albino", email = 'andrea.albino@physik.hu-berlin.de' },
@@ -29,7 +28,7 @@ authors = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    'nomad-lab>=1.3.1',
+    'nomad-lab>=1.3.14',
     'nomad-material-processing',
     'nomad-measurements',
     'nomad-analysis', # develop branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     'nomad-material-processing',
     'nomad-measurements',
     'nomad-analysis', # develop branch
-    'lakeshore-nomad-plugin', 
+    'lakeshore-nomad-plugin',
     'laytec_epitt_plugin',
     ]
 


### PR DESCRIPTION
The tests fail because the `.asc` files are matched with the parser from `nomad-measurements`, creating an entry with the `ELNUVVisNirTransmission` section def. The test expects that the files are matched with the extended parser defined in `nomad-ikz-plugin`, which creates an entry with the `IKZELNUVVisNirTransmission` section def.

This was not the issue before; perhaps we got lucky that the matching process hit the correct parser. 

As a quick fix, I added a `nomad.yaml` config file to exclude the parser coming from `nomad-measurements`.